### PR TITLE
docs: updated activation metadata value length

### DIFF
--- a/src/Cryptlex.LexFloatClient/LexFloatClient.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClient.cs
@@ -96,7 +96,7 @@ namespace Cryptlex
         /// LexFloatServer dashboard.
         /// </summary>
         /// <param name="key">string of maximum length 256 characters with utf-8 encoding</param>
-        /// <param name="value">string of maximum length 256 characters with utf-8 encoding</param>
+        /// <param name="value">string of maximum length 4096 characters with utf-8 encoding</param>
         public static void SetFloatingClientMetadata(string key, string value)
         {
             int status;

--- a/src/Cryptlex.LexFloatClient/LexFloatClientException.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClientException.cs
@@ -57,7 +57,7 @@ namespace Cryptlex
                    return "Metadata key length is more than 256 characters.";
                     
                 case LexFloatStatusCodes.LF_E_METADATA_VALUE_LENGTH:
-                   return "Metadata value length is more than 256 characters.";
+                   return "Metadata value length is more than 4096 characters.";
                     
                 case LexFloatStatusCodes.LF_E_FLOATING_CLIENT_METADATA_LIMIT:
                    return "The floating client has reached it's metadata fields limit.";

--- a/src/Cryptlex.LexFloatClient/LexFloatStatusCodes.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatStatusCodes.cs
@@ -117,7 +117,7 @@ namespace Cryptlex
         /*
             CODE: LF_E_METADATA_VALUE_LENGTH
 
-            MESSAGE: Metadata value length is more than 256 characters.
+            MESSAGE: Metadata value length is more than 4096 characters.
         */
         public const int LF_E_METADATA_VALUE_LENGTH = 53;
 


### PR DESCRIPTION
## **Type**
documentation, enhancement


___

## **Description**
- Updated the `SetFloatingClientMetadata` method to allow a `value` parameter length of up to 4096 characters, enhancing the flexibility for metadata storage.
- Modified the error message and documentation comments related to `LF_E_METADATA_VALUE_LENGTH` to reflect the new maximum length of 4096 characters.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LexFloatClient.cs</strong><dd><code>Update Metadata Value Length in SetFloatingClientMetadata Method</code></dd></summary>
<hr>
      
src/Cryptlex.LexFloatClient/LexFloatClient.cs

<li>Updated the maximum length for the <code>value</code> parameter in <br><code>SetFloatingClientMetadata</code> method from 256 to 4096 characters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cryptlex/lexfloatclient-dotnet/pull/7/files#diff-2dabed4cf1667ba406125805c1e48fc3cf64e977346dfbc328fe3623eee0c436">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LexFloatClientException.cs</strong><dd><code>Update Error Message for Metadata Value Length</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/Cryptlex.LexFloatClient/LexFloatClientException.cs

<li>Updated the error message for <code>LF_E_METADATA_VALUE_LENGTH</code> to reflect <br>the new maximum length of 4096 characters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cryptlex/lexfloatclient-dotnet/pull/7/files#diff-cb6829e7048d5f3ce8cc668fdf36acfd6491cedbbe7caa16109d45675eb222ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LexFloatStatusCodes.cs</strong><dd><code>Update Documentation for Metadata Value Length Constant</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
src/Cryptlex.LexFloatClient/LexFloatStatusCodes.cs

<li>Updated the documentation comment for <code>LF_E_METADATA_VALUE_LENGTH</code> to <br>indicate the new maximum length of 4096 characters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cryptlex/lexfloatclient-dotnet/pull/7/files#diff-4065e9c070bca47429aed1c0a478ce4e1d12a2e932f1ddf2772f9f8d41d48416">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

