### PR TITLE
feat: Add RequestOfflineFloatingLicense method for offline license leasing

### DIFF
--- a/src/Cryptlex.LexFloatClient/LexFloatClient.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClient.cs
@@ -312,6 +312,28 @@ namespace Cryptlex
         }
 
         /// <summary>
+        /// Sends the request to lease the license from the LexFloatServer for offline usage.
+        /// The maximum value of lease duration is configured in the config.yml of LexFloatServer 
+        /// </summary>
+        /// <param name="leaseDuration">value of the lease duration</param>
+        public static void RequestOfflineFloatingLicense(uint leaseDuration)
+        {
+            int status;
+            if (LexFloatClientNative.IsWindows())
+            {
+                status = IntPtr.Size == 4 ? LexFloatClientNative.RequestOfflineFloatingLicense_x86(leaseDuration) : LexFloatClientNative.RequestOfflineFloatingLicense(leaseDuration);
+            }
+            else
+            {
+                status = LexFloatClientNative.RequestOfflineFloatingLicenseA(leaseDuration);
+            }
+            if (LexFloatStatusCodes.LF_OK != status)
+            {
+                throw new LexFloatClientException(status);
+            }
+        }
+
+        /// <summary>
         ///  Sends the request to the LexFloatServer to free the license.
         /// 
         /// Call this function before you exit your application to prevent zombie licenses.

--- a/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
@@ -90,6 +90,12 @@ namespace Cryptlex
         public static extern int RequestFloatingLicense();
 
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int RequestOfflineFloatingLicense(uint leaseDuration);
+
+        [DllImport(DLL_FILE_NAME, CharSet = CharSet.Ansi, EntryPoint = "RequestOfflineFloatingLicense", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int RequestOfflineFloatingLicenseA(uint leaseDuration);
+
+        [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         public static extern int DropFloatingLicense();
 
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
@@ -152,6 +158,9 @@ namespace Cryptlex
 
         [DllImport(DLL_FILE_NAME_X86, CharSet = CharSet.Unicode, EntryPoint = "RequestFloatingLicense", CallingConvention = CallingConvention.Cdecl)]
         public static extern int RequestFloatingLicense_x86();
+
+        [DllImport(DLL_FILE_NAME_X86, CharSet = CharSet.Unicode, EntryPoint = "RequestOfflineFloatingLicense", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int RequestOfflineFloatingLicense_x86(uint leaseDuration);
 
         [DllImport(DLL_FILE_NAME_X86, CharSet = CharSet.Unicode, EntryPoint = "DropFloatingLicense", CallingConvention = CallingConvention.Cdecl)]
         public static extern int DropFloatingLicense_x86();


### PR DESCRIPTION
This pull request adds a new method, `RequestOfflineFloatingLicense`, which allows for leasing a license from the LexFloatServer for offline usage. The method takes a `leaseDuration` parameter, which specifies the duration of the lease. The maximum value of the lease duration is configured in the `config.yml` file of the LexFloatServer. 