### PR TITLE
feat: Add permission flag support for system-wide activations

### DIFF
--- a/src/Cryptlex.LexFloatClient/LexFloatClient.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClient.cs
@@ -13,6 +13,14 @@ namespace Cryptlex
         /* To prevent garbage collection of delegate, need to keep a reference */
         static readonly List<CallbackType> callbackList = new List<CallbackType>();
 
+        public enum PermissionFlags : uint
+        {
+            /// This flag indicates that the application does not require admin or root permissions to run.
+            LF_USER = 10,
+            /// This flag is specifically designed for Windows and should be used for system-wide activations.
+            LF_ALL_USERS = 11,   
+        }
+
 
         /// <summary>
         /// Sets the product id of your application.
@@ -107,6 +115,35 @@ namespace Cryptlex
             else
             {
                 status = LexFloatClientNative.SetFloatingClientMetadataA(key, value);
+            }
+            if (LexFloatStatusCodes.LF_OK != status)
+            {
+                throw new LexFloatClientException(status);
+            }
+        }
+
+        /// <summary>
+        /// Sets the permission flag.
+
+        /// This function must be called on every start of your program after SetHostProductId()
+        /// function in case the application allows borrowing of licenses or system wide activation.
+        /// </summary>
+        /// <param name="flags">
+        ///     depending on your application's requirements, choose one of the following values: LF_USER,LF_ALL_USERS.
+        ///     
+        ///     - LF_USER: This flag indicates that the application does not require admin or root permissions to run.
+        ///     - LF_ALL_USERS: This flag is specifically designed for Windows and should be used for system-wide activations.
+        /// </param>
+        public static void SetPermissionFlag(PermissionFlags flags)
+        {
+            int status;
+            if (LexFloatClientNative.IsWindows())
+            {
+                status = IntPtr.Size == 4 ? LexFloatClientNative.SetPermissionFlag_x86(flags) : LexFloatClientNative.SetPermissionFlag(flags);
+            }
+            else
+            {
+                status = LexFloatClientNative.SetPermissionFlagA(flags);
             }
             if (LexFloatStatusCodes.LF_OK != status)
             {

--- a/src/Cryptlex.LexFloatClient/LexFloatClient.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClient.cs
@@ -128,22 +128,22 @@ namespace Cryptlex
         /// This function must be called on every start of your program after SetHostProductId()
         /// function in case the application allows borrowing of licenses or system wide activation.
         /// </summary>
-        /// <param name="flags">
+        /// <param name="flag">
         ///     depending on your application's requirements, choose one of the following values: LF_USER,LF_ALL_USERS.
         ///     
         ///     - LF_USER: This flag indicates that the application does not require admin or root permissions to run.
         ///     - LF_ALL_USERS: This flag is specifically designed for Windows and should be used for system-wide activations.
         /// </param>
-        public static void SetPermissionFlag(PermissionFlags flags)
+        public static void SetPermissionFlag(PermissionFlags flag)
         {
             int status;
             if (LexFloatClientNative.IsWindows())
             {
-                status = IntPtr.Size == 4 ? LexFloatClientNative.SetPermissionFlag_x86(flags) : LexFloatClientNative.SetPermissionFlag(flags);
+                status = IntPtr.Size == 4 ? LexFloatClientNative.SetPermissionFlag_x86(flag) : LexFloatClientNative.SetPermissionFlag(flag);
             }
             else
             {
-                status = LexFloatClientNative.SetPermissionFlagA(flags);
+                status = LexFloatClientNative.SetPermissionFlagA(flag);
             }
             if (LexFloatStatusCodes.LF_OK != status)
             {

--- a/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
@@ -31,6 +31,13 @@ namespace Cryptlex
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Ansi, EntryPoint = "SetHostUrl", CallingConvention = CallingConvention.Cdecl)]
         public static extern int SetHostUrlA(string hostUrl);
 
+        
+        [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SetPermissionFlag(LexFloatClient.PermissionFlags flags);
+
+        [DllImport(DLL_FILE_NAME, CharSet = CharSet.Ansi, EntryPoint = "SetPermissionFlag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SetPermissionFlagA(LexFloatClient.PermissionFlags flags);
+
 
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
         public static extern int SetFloatingLicenseCallback(LexFloatClient.CallbackType callback);
@@ -113,6 +120,8 @@ namespace Cryptlex
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Ansi, EntryPoint = "ResetFloatingClientMeterAttributeUses", CallingConvention = CallingConvention.Cdecl)]
         public static extern int ResetFloatingClientMeterAttributeUsesA(string name);
 
+        [DllImport(DLL_FILE_NAME_X86, CharSet = CharSet.Unicode, EntryPoint = "SetPermissionFlag", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int SetPermissionFlag_x86(LexFloatClient.PermissionFlags flags);
 
         [DllImport(DLL_FILE_NAME_X86, CharSet = CharSet.Unicode, EntryPoint = "SetHostProductId", CallingConvention = CallingConvention.Cdecl)]
         public static extern int SetHostProductId_x86(string productId);

--- a/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClientNative.cs
@@ -33,10 +33,10 @@ namespace Cryptlex
 
         
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int SetPermissionFlag(LexFloatClient.PermissionFlags flags);
+        public static extern int SetPermissionFlag(LexFloatClient.PermissionFlags flag);
 
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Ansi, EntryPoint = "SetPermissionFlag", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int SetPermissionFlagA(LexFloatClient.PermissionFlags flags);
+        public static extern int SetPermissionFlagA(LexFloatClient.PermissionFlags flag);
 
 
         [DllImport(DLL_FILE_NAME, CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
This pull request adds support for setting permission flags in the software. The `SetPermissionFlag` function has been added to the `LexFloatClient` class, allowing the application to specify whether it requires admin or root permissions to run (`LF_USER`) or if it should be used for system-wide activations on Windows (`LF_ALL_USERS`). 