### PR TITLE
Set Buffer to 4096 same as lexactivator client for GetHostLicenseMet…

### DIFF
--- a/src/Cryptlex.LexFloatClient/LexFloatClient.cs
+++ b/src/Cryptlex.LexFloatClient/LexFloatClient.cs
@@ -451,7 +451,7 @@ namespace Cryptlex
         /// <returns>Returns the value of metadata for the key.</returns>
         public static string GetHostLicenseMetadata(string key)
         {
-            var builder = new StringBuilder(256);
+            var builder = new StringBuilder(4096);
             int status;
             if (LexFloatClientNative.IsWindows())
             {


### PR DESCRIPTION
We store data in metadata this works fine using the lexactivator client but the lexfloatclient has different limits set